### PR TITLE
Fixed youtube-dl format options

### DIFF
--- a/process.py
+++ b/process.py
@@ -1,4 +1,6 @@
-import youtube_dl, os, threading, logging, json
+import youtube_dl
+import os, threading, logging, json
+
 with open('raspberrycast.conf') as f:    
     config = json.load(f)
 logger = logging.getLogger("RaspberryCast")
@@ -45,7 +47,12 @@ def return_full_url(url, sub=False):
 		logger.debug('Direct video URL, no need to use youtube-dl.')
 		return url
 
-	ydl = youtube_dl.YoutubeDL({'logger': logger, 'noplaylist': True, 'ignoreerrors': True}) # Ignore errors in case of error in long playlists
+	ydl_options = {
+		'logger': logger, 
+		'noplaylist': True, 
+		'ignoreerrors': True,
+		'format': 'best[ext=mp4]/best'}
+	ydl = youtube_dl.YoutubeDL(ydl_options) # Ignore errors in case of error in long playlists
 	with ydl: #Downloading youtub-dl infos
 	    result = ydl.extract_info(url, download=False) #We just want to extract the info
 

--- a/process.py
+++ b/process.py
@@ -47,11 +47,18 @@ def return_full_url(url, sub=False):
 		logger.debug('Direct video URL, no need to use youtube-dl.')
 		return url
 
-	ydl_options = {
-		'logger': logger, 
-		'noplaylist': True, 
-		'ignoreerrors': True,
-		'format': 'best[ext=mp4]/best'}
+	if slow:
+		ydl_options = {
+			'logger': logger, 
+			'noplaylist': True, 
+			'ignoreerrors': True,
+			'format': 'mp4[height<=480]/best[height<=480]'}
+	else:
+		ydl_options = {
+			'logger': logger, 
+			'noplaylist': True, 
+			'ignoreerrors': True,
+			'format': 'mp4/best'}
 	ydl = youtube_dl.YoutubeDL(ydl_options) # Ignore errors in case of error in long playlists
 	with ydl: #Downloading youtub-dl infos
 	    result = ydl.extract_info(url, download=False) #We just want to extract the info


### PR DESCRIPTION
I had a bit of a time getting this to work because return_full_url wasn't able to pull the URL from video['url']. Eventually found that this was because the youtube-dl was pulling a DASH video/audio pair and their object layout is different for those. Adding the 'format: best' option specifically limits it to the best single source and provides the URL in the expected location.