### PR TITLE
Clarify output, fix a possible syntax error and add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 vincelwt
+Copyright (c) 2018 Vincent Loewert
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 vincelwt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/RaspberryCast.sh
+++ b/RaspberryCast.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [ $# -ne 1 ]; then
+        echo "Error: This script takes exactly one argument."
+        echo "The argument should be either 'start' or 'stop'."
+        exit
+fi
+
 if [ $1 = "start" ]; then
 	if [ `id -u` -eq 0 ]
 	then
@@ -29,6 +35,6 @@ elif [ $1 = "stop" ] ; then
 	echo "Done."
 	exit
 else
-	echo "Error, wrong argument. Try with 'stop', 'start'."
+	echo "Error, illegal argument. Possible values are: 'stop', 'start'."
 	exit
 fi


### PR DESCRIPTION
If the user gave no arguments to RaspberryCast.sh, it would output a syntax error (as seen in #49 ). Would be fixed in this case by exiting if the number of arguments is not 1.

I've also added an MIT License file. This makes it easier for GitHub to categorize the project, and also clarifies the terms of use. Ideally it should have the full name of @vincelwt , but that's not necessary.