### PR TITLE
make server.py Python3 compatible

### DIFF
--- a/server.py
+++ b/server.py
@@ -4,7 +4,12 @@ import logging
 import os
 import sys
 import json
-import urllib
+try:
+    # this works in Python3
+    from urllib.request import urlretrieve
+except ImportError:
+    # this works in Python2
+    from urllib import urlretrieve
 from bottle import Bottle, SimpleTemplate, request, response, \
                    template, run, static_file
 from process import launchvideo, queuevideo, playlist, \
@@ -106,7 +111,7 @@ Replacing with remote IP.''')
                                 .replace('127.0.0.1', ip)
 
             logger.debug('Subtitles link is '+subtitles)
-            urllib.urlretrieve(subtitles, "subtitle.srt")
+            urlretrieve(subtitles, "subtitle.srt")
             launchvideo(url, config, sub=True)
         else:
             logger.debug('No subtitles for this stream')
@@ -117,7 +122,7 @@ Replacing with remote IP.''')
             else:
                 launchvideo(url, config, sub=False)
             return "1"
-    except Exception, e:
+    except Exception as e:
         logger.error(
             'Error in launchvideo function or during downlading the subtitles')
         logger.exception(e)
@@ -155,7 +160,7 @@ def queue():
             else:
                 launchvideo(url, config, sub=False)
             return "1"
-    except Exception, e:
+    except Exception as e:
         logger.error('Error in launchvideo or queuevideo function !')
         logger.exception(e)
         return "0"


### PR DESCRIPTION
This makes `server.py` compatible with both Python2 and Python3.
The `expect as e` syntax works since Python 2.6, including all versions
of Python3. The urllib changed structure between Python2 and Python3

`process.py` was already 2/3 compatible. `rcast.py` needs a lot of work,
but can be done separately since it is run on another host.
`YoutubeFullUrl.py` is not used anywhere.

Fixes #56