### PR TITLE
Switch default to Python3, and change deps installation

### DIFF
--- a/RaspberryCast.sh
+++ b/RaspberryCast.sh
@@ -15,8 +15,19 @@ if [ $1 = "start" ]; then
 	fi
 	echo "Checking for updates."
 	git pull
-	echo "Starting RaspberryCast server."
-	./server.py &
+	# This block checks dependencies in Python3, and if that fails in
+	# Python2.
+	# TODO: Transition existing installations to Python3?
+	if python3 -c "import bottle, youtube_dl" 2>/dev/null; then
+		echo "Starting RaspberryCast server on Python3."
+		python3 server.py &
+	elif python2 -c "import bottle, youtube_dl" 2>/dev/null; then
+		echo "Starting RaspberryCast server on Python2."
+		python2 server.py &
+	else
+		echo "Missing dependencies, read README.md for installation instructions." >&2
+		exit 1
+	fi
 	echo "Done."
 	exit
 elif [ $1 = "stop" ] ; then

--- a/server.py
+++ b/server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import logging
 import os

--- a/setup.sh
+++ b/setup.sh
@@ -39,20 +39,12 @@ echo "Installing necessary dependencies... (This could take a while)"
 echo ""
 echo "============================================================"
 
-apt-get install -y lsof python-pip git wget omxplayer libnss-mdns fbi
+apt-get install -y lsof git wget omxplayer libnss-mdns fbi python3 python3-bottle youtube-dl
 echo "============================================================"
 
 if [ "$?" = "1" ]
 then
   echo "An unexpected error occured during apt-get!"
-  exit 0
-fi
-
-pip install youtube-dl bottle livestreamer
-
-if [ "$?" = "1" ]
-then
-  echo "An unexpected error occured durin pip install!"
   exit 0
 fi
 


### PR DESCRIPTION
`setup.sh` used to install some dependencies with `apt-get` and some
with `pip`. In the pip part, we had `livestreamer`, which is not inuse,
and `youtube-dl` and `bottle` which both exist in Raspbian repositories
for Python3. So instead of the mix (which is problematic, because no one
ever updates pip deps), we install it all with apt-get.

This required to switch to Python3. The problem is that existing users
with a self-updating git installation will not see this change. So for
backwards compatibility I added a simple dependency check before running
the main script.