### PR TITLE
View streaming history

### DIFF
--- a/static/history.js
+++ b/static/history.js
@@ -59,10 +59,9 @@ function updateHistoryDiv() {
             });
 
             $("#history-div").empty();
-            $("#history-div").append("<hr>");
 
             for (var i = uniqueArray.length - 1; i >= 0; i--) {
-                  
+
                   var historyLink = $("<a class='history-link-item' href='#'>" + uniqueArray[i] + "</a>").click(function() {
                         var encoded_url = encodeURIComponent($(this).text());
                         mkrequest("/stream?url=" + encoded_url, 1);

--- a/static/history.js
+++ b/static/history.js
@@ -62,9 +62,9 @@ function updateHistoryDiv() {
             $("#history-div").append("<hr>");
 
             for (var i = uniqueArray.length - 1; i >= 0; i--) {
-                  var encoded_url = encodeURIComponent(uniqueArray[i]);
-
+                  
                   var historyLink = $("<a class='history-link-item' href='#'>" + uniqueArray[i] + "</a>").click(function() {
+                        var encoded_url = encodeURIComponent($(this).text());
                         mkrequest("/stream?url=" + encoded_url, 1);
                   });
 

--- a/static/history.js
+++ b/static/history.js
@@ -1,0 +1,84 @@
+/* To manage history content we use localStorage to save data. */
+
+var historyArray = [];
+
+function storageAvailable(type) {
+	try {
+		var storage = window[type],
+		x = '__storage_test__';
+		storage.setItem(x, x);
+		storage.removeItem(x);
+		return true;
+	}
+	catch(e) {
+		return e instanceof DOMException && (
+            // everything except Firefox
+            e.code === 22 ||
+            // Firefox
+            e.code === 1014 ||
+            // test name field too, because code might not be present
+            // everything except Firefox
+            e.name === 'QuotaExceededError' ||
+            // Firefox
+            e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
+            // acknowledge QuotaExceededError only if there's something already stored
+            storage.length !== 0;
+      }
+}
+
+
+function addToHistory(url) {
+      if (storageAvailable('localStorage')) {
+            //Retreive the history, create an empty array if it does not exist
+            historyArray = JSON.parse(localStorage.getItem('history'));
+      
+            if (!historyArray)
+            historyArray = [];
+
+            url = url.replace(/\"/g, "");
+
+            //Don't add duplicates to the history
+            //A possible enhancement would be to push it to the top of the array
+            if (!historyArray.includes(url))  
+                  historyArray.push(url);
+
+            localStorage.setItem('history', JSON.stringify(historyArray));
+      }
+}
+
+function updateHistoryDiv() {
+      if (storageAvailable('localStorage')) {
+            historyArray = JSON.parse(localStorage.getItem('history'));
+            
+            if (!historyArray) {
+                  return;
+            }
+
+            uniqueArray = historyArray.filter(function(item, pos) {
+                  return historyArray.indexOf(item) == pos;
+            });
+
+            $("#history-div").empty();
+            $("#history-div").append("<hr>");
+
+            for (var i = uniqueArray.length - 1; i >= 0; i--) {
+                  var encoded_url = encodeURIComponent(uniqueArray[i]);
+
+                  var historyLink = $("<a class='history-link-item' href='#'>" + uniqueArray[i] + "</a>").click(function() {
+                        mkrequest("/stream?url=" + encoded_url, 1);
+                  });
+
+                  $("#history-div").append(historyLink);  //Add the link.
+                  $("#history-div").append("<hr>");
+            }
+
+            var clearHistoryLink = $("<a id='clear-history-link-item' href=''>Clear history</a>").click(function() {
+                  localStorage.clear();
+                  $( "#history-div" ).toggle("fast");
+            });
+
+            $("#history-div").append(clearHistoryLink);  //Add the link.
+            $("#history-div").append("<hr>");
+
+      }
+}

--- a/static/remote.css
+++ b/static/remote.css
@@ -1,8 +1,7 @@
 #whole {
 	width: 100%;
 	max-width: 500px;
-	height: 240px;
-	
+	height: 240px;	
 }
 
 .fifty {
@@ -40,6 +39,22 @@ span.glyphicon {
 span.tb {
 	top: -20px;
 	font-size: 1.2em;
+}
+
+#last-div {
+	padding-bottom: 20px;
+}
+
+
+#history-div {
+	width: 93%;
+	text-align: left;
+	font-size: 1.2em;
+}
+
+#clear-history-link-item {
+	font-style: bold;
+	color: red;
 }
 
 #clear_search {

--- a/static/remote.js
+++ b/static/remote.js
@@ -24,12 +24,19 @@ function advanced() {
 }
 
 
+function showHistory() {
+	//Only update history when div is being toggled ON
+	if (!$( "#history-div" ).is(":visible"))
+		updateHistoryDiv();
+
+	$( "#history-div" ).toggle("fast");
+}
 
 function mkrequest(url, response) {
 	try {
 		var newURL = document.location.origin+url;
 		if (response == 1 ) {
-			message("Trying to get video stream URL. Please wait ~ 10-30 seconds.", 0);
+			message("Trying to get video stream URL. Please wait ~10 seconds.", 0);
 		} else if (response == 2 ) {
 			message("Trying to add video to queue. ", 0);
 		} else if (response == 3 ) {
@@ -43,13 +50,13 @@ function mkrequest(url, response) {
 				if (req.status == 200) {
 					if (req.responseText == "1") {
 						if (response == 1) {
-							message("Success ! Video should now be playing.", 1);	
+							message("Success! Video should now be playing.", 1);	
 						} else if (response == 2) {
-							message("Success ! Video has been added to queue.", 1);	
+							message("Success! Video has been added to queue.", 1);	
 						} else if (response == 3) {
-							message("Success ! Shutdown has been successfully programmed.", 1);	
+							message("Success! Shutdown has been successfully scheduled.", 1);	
 						} else if (response == 4) {
-							message("Success ! Shutdown has been cancelled.", 1);	
+							message("Success! Shutdown has been cancelled.", 1);	
 						}
 						
 					} else {
@@ -63,7 +70,7 @@ function mkrequest(url, response) {
 		req.send(null);
 	} 
 	catch(err) {
-		message("Error ! Make sure the ip/port are corrects, and the server is running.")
+		message("Error! Make sure the IP and port is correct, and that the server is running.")
 	}
 }
 
@@ -73,7 +80,8 @@ $(function() {
 		if ( $( "#media_url" ).val() !== "" ) {
 			var url = $( "#media_url" ).val();
 			var url_encoded_url = encodeURIComponent(url);
-			mkrequest("/stream?url=" + url_encoded_url, 1)
+			addToHistory(url);
+			mkrequest("/stream?url=" + url_encoded_url, 1);
 		} else {
 			message("You must enter a link !", 2)
 		}	
@@ -90,18 +98,18 @@ $(function() {
 	});
 
 	$("#clear_search").click(function(){
-    	$("#media_url").val('');
-    	$("#clear_search").hide();
+		$("#media_url").val('');
+		$("#clear_search").hide();
 	});
 
 	$("#media_url").keyup(function(){
-    if($(this).val()) {
-        $("#clear_search").show();
-    } else {
-        $("#clear_search").hide();
-    }
-        
-});
+		if($(this).val()) {
+			$("#clear_search").show();
+		} else {
+			$("#clear_search").hide();
+		}
+
+	});
 
 	$( "#shutbtn" ).click(function() {
 		if ( $( "#time_shut" ).val() !== "" ) {

--- a/views/remote.tpl
+++ b/views/remote.tpl
@@ -2,7 +2,7 @@
 	<head>
 		<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 		<meta charset="utf-8">
-		<title>RaspberryCast</title>
+		<title> LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL RaspberryCast</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 		<link href="{{get_url('static', filename='remote.css') }}" rel="stylesheet">
 		<link href="{{get_url('static', filename='bootstrap.min.css') }}" rel="stylesheet">
@@ -83,6 +83,25 @@
 							</span>
 						</button>
 					</div>
+					<!-- History and playlist management -->
+					<div>
+						<button id="history-button" onClick="showHistory()" type="button" title="History" class="ninety btn btn-warning">
+							<span class="tb">
+								<span class="glyphicon glyphicon-list-alt  pull-left" aria-hidden="true"></span>
+								History
+							</span>
+						</button>
+					</div>
+					<div id="history-div" style="display:none">
+					</div>
+					<div id="last-div">
+						<button id="playlist-button" type="button" title="Playlist management" class="ninety btn btn-primary">
+							<span class="tb">
+								<span class="glyphicon glyphicon-edit pull-left" aria-hidden="true"></span>
+								Manage playlists
+							</span>
+						</button>
+					</div>
 				</div>
 			
 		</div>
@@ -92,6 +111,7 @@
 		<!-- script references -->
 		
 		<script src="{{get_url('static', filename='jquery-2.1.3.min.js') }}"></script>
+		<script src="{{get_url('static', filename='history.js') }}"></script>
 		<script src="{{get_url('static', filename='remote.js') }}"></script>
 	</body>
 </html>

--- a/views/remote.tpl
+++ b/views/remote.tpl
@@ -2,7 +2,7 @@
 	<head>
 		<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 		<meta charset="utf-8">
-		<title> LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL LOCAL RaspberryCast</title>
+		<title>RaspberryCast</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 		<link href="{{get_url('static', filename='remote.css') }}" rel="stylesheet">
 		<link href="{{get_url('static', filename='bootstrap.min.css') }}" rel="stylesheet">

--- a/views/remote.tpl
+++ b/views/remote.tpl
@@ -84,7 +84,7 @@
 						</button>
 					</div>
 					<!-- History and playlist management -->
-					<div>
+					<div id="last-div">
 						<button id="history-button" onClick="showHistory()" type="button" title="History" class="ninety btn btn-warning">
 							<span class="tb">
 								<span class="glyphicon glyphicon-list-alt  pull-left" aria-hidden="true"></span>
@@ -93,14 +93,6 @@
 						</button>
 					</div>
 					<div id="history-div" style="display:none">
-					</div>
-					<div id="last-div">
-						<button id="playlist-button" type="button" title="Playlist management" class="ninety btn btn-primary">
-							<span class="tb">
-								<span class="glyphicon glyphicon-edit pull-left" aria-hidden="true"></span>
-								Manage playlists
-							</span>
-						</button>
 					</div>
 				</div>
 			


### PR DESCRIPTION
This will update the remote view, adding a button at the bottom of the advanced settings that toggles a list of previously streamed sites. All items in this list are links, and when clicked on will attempt to stream said link. There is an option to clear the history at the bottom of the list.

This is mainly aimed at users (like myself) using the remote view on mobile to cast Twitch streams. The history is provided "as-is", meaning that ugly URLs will look ugly in the history.

![screenshot from 2018-07-02 14-09-38](https://user-images.githubusercontent.com/2301054/42163163-c82328a0-7e01-11e8-8baa-bc27afdfc65d.png)

This PR should not break any existing functionality, but feedback is always appreciated :slightly_smiling_face: 